### PR TITLE
feat: expand usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### New Redis cache
 
-```
+```go
 cache, err := NewRedisCache(context.Background(), "localhost:6379", 5*time.Second)
 if err != nil {
     panic(err)
@@ -23,7 +23,7 @@ fmt.Println(v)
 
 ### New libcache (in-process cache)
 
-```
+```go
 cache, err := NewLibcache(0, 5*time.Second)
 if err != nil {
     panic(err)

--- a/icache.go
+++ b/icache.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"context"
 	"errors"
 )
 
@@ -10,10 +11,28 @@ type Cache interface {
 	Del(key string) error
 
 	BatchGet(keys ...string) ([][]byte, error)
+	// BatchSet
 	// key1, value1, key2, value2 ...
 	// string, bytes, string,bytes
 	BatchSet(keyvalues ...interface{}) error
 	Close() error
 }
 
-var ErrCacheMiss = errors.New("not found in cache")
+type CacheCtx interface {
+	SetCtx(ctx context.Context, key string, value []byte) error
+	GetCtx(ctx context.Context, key string) ([]byte, error)
+	DelCtx(ctx context.Context, key string) error
+
+	BatchGetCtx(ctx context.Context, keys ...string) ([][]byte, error)
+	// BatchSetCtx
+	// key1, value1, key2, value2 ...
+	// string, bytes, string,bytes
+	BatchSetCtx(ctx context.Context, keyvalues ...interface{}) error
+	CloseCtx(ctx context.Context) error
+}
+
+var (
+	ErrCacheMiss    = errors.New("not found in cache")
+	ErrInvalidKey   = errors.New("key is invalid")
+	ErrInvalidValue = errors.New("value is invalid")
+)


### PR DESCRIPTION
I'd like to propose some changes to improve usability, this is my personal view especially on packages to be used in different services, with multiple possible use cases without breaking changes

As such, it's open for discussion, so I've gone into more details as comments in the code to trigger them, but here's a brief resume on some key points

## Context in the interface
caches usually interact with infrastructure, it helps to have the [context in the interface](https://github.com/golang/go/wiki/CodeReviewComments#contexts).

## Return structs from constructors
there's no benefit from returning interfaces from constructors, it's generally accepted that [returning structs](https://github.com/golang/go/wiki/CodeReviewComments#interfaces) and injecting interfaces gives more flexibility to the user

## Inject dependencies
It's ok to have helpers to construct and init the most common use cases, but injecting dependencies allows the client to customize them. For example, in the Redis cache, we cannot customize the database index or any other parameter.

Ideally, a constructor should not perform I/O ops that could lead to errors, IMO it's ok to do some validations of the parameters though since those are fast operations.

## Prevent panics
is [advisable](https://github.com/golang/go/wiki/CodeReviewComments#dont-panic) to prevent panics, this not only applies to calling `panic` directly but also things like type assertions, out of bounds...
