### PR TITLE
chore: unify cacheCtx and cache, fix tests

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -17,7 +17,7 @@ func TestSetGet(t *testing.T) {
 	cache.Set(ctx, "key1", []byte("hello1"))
 	cache.Set(ctx, "key2", []byte("hello2"))
 
-	v, err := cache.Get(context.Background(), "key2")
+	v, err := cache.Get(ctx, "key2")
 	assert.Nil(t, err)
 
 	assert.Equal(t, []byte("hello2"), v)
@@ -27,9 +27,10 @@ func TestBatchSetGet(t *testing.T) {
 	cache, err := NewLibcache(0, 5*time.Second)
 	assert.Nil(t, err)
 
-	cache.BatchSet(context.Background(), "key1", []byte("value1"), "key2", []byte("value2"), "key3", []byte("value3"))
+	ctx := context.Background()
+	cache.BatchSet(ctx, "key1", []byte("value1"), "key2", []byte("value2"), "key3", []byte("value3"))
 
-	v, err := cache.BatchGet(context.Background(), "key3", "key2")
+	v, err := cache.BatchGet(ctx, "key3", "key2")
 	assert.Nil(t, err)
 
 	assert.Equal(t, []byte("value3"), v[0])

--- a/cache_test.go
+++ b/cache_test.go
@@ -13,10 +13,11 @@ func TestSetGet(t *testing.T) {
 	cache, err := NewLibcache(0, 5*time.Second)
 	assert.Nil(t, err)
 
-	cache.Set("key1", []byte("hello1"))
-	cache.Set("key2", []byte("hello2"))
+	ctx := context.Background()
+	cache.Set(ctx, "key1", []byte("hello1"))
+	cache.Set(ctx, "key2", []byte("hello2"))
 
-	v, err := cache.Get("key2")
+	v, err := cache.Get(context.Background(), "key2")
 	assert.Nil(t, err)
 
 	assert.Equal(t, []byte("hello2"), v)
@@ -26,9 +27,9 @@ func TestBatchSetGet(t *testing.T) {
 	cache, err := NewLibcache(0, 5*time.Second)
 	assert.Nil(t, err)
 
-	cache.BatchSet("key1", []byte("value1"), "key2", []byte("value2"), "key3", []byte("value3"))
+	cache.BatchSet(context.Background(), "key1", []byte("value1"), "key2", []byte("value2"), "key3", []byte("value3"))
 
-	v, err := cache.BatchGet("key3", "key2")
+	v, err := cache.BatchGet(context.Background(), "key3", "key2")
 	assert.Nil(t, err)
 
 	assert.Equal(t, []byte("value3"), v[0])

--- a/icache.go
+++ b/icache.go
@@ -6,29 +6,16 @@ import (
 )
 
 type Cache interface {
-	Set(key string, value []byte) error
-	Get(key string) ([]byte, error)
-	Del(key string) error
+	Set(ctx context.Context, key string, value []byte) error
+	Get(ctx context.Context, key string) ([]byte, error)
+	Del(ctx context.Context, key string) error
 
-	BatchGet(keys ...string) ([][]byte, error)
+	BatchGet(ctx context.Context, keys ...string) ([][]byte, error)
 	// BatchSet
 	// key1, value1, key2, value2 ...
 	// string, bytes, string,bytes
-	BatchSet(keyvalues ...interface{}) error
+	BatchSet(ctx context.Context, keyvalues ...interface{}) error
 	Close() error
-}
-
-type CacheCtx interface {
-	SetCtx(ctx context.Context, key string, value []byte) error
-	GetCtx(ctx context.Context, key string) ([]byte, error)
-	DelCtx(ctx context.Context, key string) error
-
-	BatchGetCtx(ctx context.Context, keys ...string) ([][]byte, error)
-	// BatchSetCtx
-	// key1, value1, key2, value2 ...
-	// string, bytes, string,bytes
-	BatchSetCtx(ctx context.Context, keyvalues ...interface{}) error
-	CloseCtx(ctx context.Context) error
 }
 
 var (

--- a/inprocess_cache.go
+++ b/inprocess_cache.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -25,13 +26,13 @@ func NewLibcache(cap int, ttl time.Duration) (*memLibCache, error) {
 	}, nil
 }
 
-func (l *memLibCache) Set(key string, value []byte) (err error) {
+func (l *memLibCache) Set(ctx context.Context, key string, value []byte) (err error) {
 	// with default ttl
 	l.cache.Store(key, value)
 	return nil
 }
 
-func (l *memLibCache) Get(key string) ([]byte, error) {
+func (l *memLibCache) Get(ctx context.Context, key string) ([]byte, error) {
 	value, exist := l.cache.Load(key)
 	if !exist {
 		return nil, ErrCacheMiss
@@ -39,12 +40,12 @@ func (l *memLibCache) Get(key string) ([]byte, error) {
 	return value.([]byte), nil
 }
 
-func (l *memLibCache) Del(key string) (err error) {
+func (l *memLibCache) Del(ctx context.Context, key string) (err error) {
 	l.cache.Delete(key)
 	return nil
 }
 
-func (l *memLibCache) BatchGet(keys ...string) (result [][]byte, err error) {
+func (l *memLibCache) BatchGet(ctx context.Context, keys ...string) (result [][]byte, err error) {
 	for _, k := range keys {
 		value, exist := l.cache.Load(k)
 		if !exist {
@@ -56,7 +57,7 @@ func (l *memLibCache) BatchGet(keys ...string) (result [][]byte, err error) {
 	return result, nil
 }
 
-func (l *memLibCache) BatchSet(keyvalues ...interface{}) error {
+func (l *memLibCache) BatchSet(ctx context.Context, keyvalues ...interface{}) error {
 	if len(keyvalues)%2 != 0 {
 		return errors.New("keyvalues len must be even")
 	}

--- a/redis.go
+++ b/redis.go
@@ -10,19 +10,16 @@ import (
 )
 
 var (
-	_ Cache    = (*redisCache)(nil)
-	_ CacheCtx = (*redisCache)(nil)
+	_ Cache = (*redisCache)(nil)
 )
 
 type redisCache struct {
-	ctx    context.Context
 	client *rediscache.Client
 	ttl    time.Duration
 }
 
-func NewRedisCacheWithClient(client *rediscache.Client, ttl time.Duration) *redisCache {
+func NewRedisCacheWithClient(ctx context.Context, client *rediscache.Client, ttl time.Duration) *redisCache {
 	return &redisCache{
-		ctx:    context.Background(),
 		client: client,
 		ttl:    ttl,
 	}
@@ -40,14 +37,13 @@ func NewRedisCache(ctx context.Context, cacheURL string, ttl time.Duration) (*re
 		return nil, fmt.Errorf("redis cache err: %w", err)
 	}
 
-	c := NewRedisCacheWithClient(client, ttl)
-	c.ctx = ctx
+	c := NewRedisCacheWithClient(ctx, client, ttl)
 
 	return c, nil
 }
 
-func (r *redisCache) Set(key string, value []byte) error {
-	return r.SetCtx(r.ctx, key, value)
+func (r *redisCache) Set(ctx context.Context, key string, value []byte) error {
+	return r.SetCtx(ctx, key, value)
 }
 
 func (r *redisCache) SetCtx(ctx context.Context, key string, value []byte) error {
@@ -58,8 +54,8 @@ func (r *redisCache) SetCtx(ctx context.Context, key string, value []byte) error
 	return nil
 }
 
-func (r *redisCache) Get(key string) ([]byte, error) {
-	return r.GetCtx(r.ctx, key)
+func (r *redisCache) Get(ctx context.Context, key string) ([]byte, error) {
+	return r.GetCtx(ctx, key)
 }
 
 func (r *redisCache) GetCtx(ctx context.Context, key string) ([]byte, error) {
@@ -70,8 +66,8 @@ func (r *redisCache) GetCtx(ctx context.Context, key string) ([]byte, error) {
 	return result.Bytes()
 }
 
-func (r *redisCache) Del(key string) error {
-	return r.DelCtx(r.ctx, key)
+func (r *redisCache) Del(ctx context.Context, key string) error {
+	return r.DelCtx(ctx, key)
 }
 
 func (r *redisCache) DelCtx(ctx context.Context, key string) error {
@@ -82,8 +78,8 @@ func (r *redisCache) DelCtx(ctx context.Context, key string) error {
 	return nil
 }
 
-func (r *redisCache) BatchGet(keys ...string) (cachedValues [][]byte, err error) {
-	return r.BatchGetCtx(r.ctx, keys...)
+func (r *redisCache) BatchGet(ctx context.Context, keys ...string) (cachedValues [][]byte, err error) {
+	return r.BatchGetCtx(ctx, keys...)
 }
 
 func (r *redisCache) BatchGetCtx(ctx context.Context, keys ...string) (cachedValues [][]byte, err error) {
@@ -114,8 +110,8 @@ func (r *redisCache) BatchGetCtx(ctx context.Context, keys ...string) (cachedVal
 	return cachedValues, nil
 }
 
-func (r *redisCache) BatchSet(keyvalues ...interface{}) error {
-	return r.BatchSetCtx(r.ctx, keyvalues...)
+func (r *redisCache) BatchSet(ctx context.Context, keyvalues ...interface{}) error {
+	return r.BatchSetCtx(ctx, keyvalues...)
 }
 
 func (r *redisCache) BatchSetCtx(ctx context.Context, keyvalues ...interface{}) error {


### PR DESCRIPTION
# Context

- We now have 2 interface which might be confused -> unify to one before it's even widely used 